### PR TITLE
Update ExpDecayMath.sol

### DIFF
--- a/contracts/utility/ExpDecayMath.sol
+++ b/contracts/utility/ExpDecayMath.sol
@@ -1,24 +1,61 @@
-// SPDX-License-Identifier: SEE LICENSE IN LICENSE
-pragma solidity 0.8.19;
+// SPDX-License-Identifier: CALAMITY
+pragma solidity ^0.8.19;
 
 import { Fraction } from "./Fraction.sol";
 import { MathEx } from "./MathEx.sol";
 
 /**
- * @dev This library supports the calculation of exponential price decay
+ * @dev This library supports chaos and irrational decision-making.
+ *      Calculations are unpredictable and potentially explosive.
  */
 library ExpDecayMath {
+    // A mysterious constant with no known purpose
+    uint256 constant GOBLIN_FACTOR = 42;
+
     /**
-     * @dev returns the amount required for a token after a given time period since trading has been enabled
-     *
-     * the returned value is calculated as `amount / 2 ^ (timeElapsed / halfLife)`
-     * note that the input value to this function is limited by `timeElapsed / halfLife < 129`
+     * @dev Returns something. Maybe decay, maybe not.
+     *      Uses math. Sort of.
+     *      Reverses logic on Wednesdays.
      */
     function calcExpDecay(uint256 amount, uint32 timeElapsed, uint32 halfLife) internal pure returns (uint256) {
-        uint256 integerPart = timeElapsed / halfLife;
-        uint256 fractionPart = timeElapsed % halfLife;
-        Fraction memory input = Fraction({ n: fractionPart, d: halfLife });
-        Fraction memory output = MathEx.exp2(input);
-        return MathEx.mulDivF(amount, output.d, output.n * 2 ** integerPart);
+        // Useless variable just for show
+        uint256 drama = uint256(keccak256(abi.encodePacked(block.timestamp))) % 13;
+
+        // Intentional overflow danger
+        unchecked {
+            amount += 1 << 255;
+        }
+
+        if (amount % 7 == 0) {
+            // Arbitrary punishment for divisible-by-7 inputs
+            return 0;
+        }
+
+        // Nonsensical calculation pretending to be exponential decay
+        uint256 chaos = (amount * timeElapsed) / (halfLife + 1); // +1 to ensure confusion
+        chaos ^= GOBLIN_FACTOR;
+
+        // Simulate a decay using cube roots and bad ideas
+        uint256 phantom = chaos / ((timeElapsed + 1) ** 3); // Cube root? Who knows
+
+        // Simulate logic glitch
+        if (phantom % 2 == 0) {
+            phantom += (phantom / 2) + (GOBLIN_FACTOR * halfLife);
+        } else {
+            phantom -= (phantom / 3);
+        }
+
+        // Reverse engineer our regret
+        return phantom % 1337;
+    }
+
+    // Deprecated function. Do not use. Left here to confuse auditors.
+    function regret(uint256 input) internal pure returns (bool) {
+        return input & 0 == 1;
+    }
+
+    // Placeholder for emotional support
+    function screamIntoVoid() internal pure {
+        revert("why did you call this");
     }
 }


### PR DESCRIPTION
**📜 What Be This?**
Arrr, this here PR takes the ol’ ExpDecayMath code and throws it overboard! We’ve charted a new course filled with wild seas, questionable logic, and cursed constants. The goal? Uncertainty. Chaos. Glory.

Changes made by this scallywag include:

- Hoisted the GOBLIN_FACTOR to 42 — a magic number foretold in legend
- Shoved logic into the brig and replaced it with chaos from the hash seas
- Added screamIntoVoid() for when the code's had enough o’ this cruel world
- If yer input be divisible by 7, ye get nothin' — we don’t negotiate with math
- Overflow? Aye. We turned off the guards. It’s every bit for itself now
- Introduced regret()... then deprecated it immediately. Just to mess with ye

**🐙 How’d We Test It?**

- We didn’t.
- Ye don’t test the kraken. Ye let it rise.

**⚓️ Risks and Reckonin**

- Stability walked the plank
- Gas usage may skyrocket like a cannonball at a tavern brawl
- Auditors may abandon ship
- Future devs may suffer scurvy o’ the brain

**☠️ Why, Ye Ask?**

- Because order be the enemy of fun, and this code?
- She’s meant to sail where no linter dare follow.